### PR TITLE
Disabling chat notifications by default

### DIFF
--- a/chrome_extension/js/turntable.fm.extend.js
+++ b/chrome_extension/js/turntable.fm.extend.js
@@ -10,7 +10,7 @@ TFMEX = {};
 
 TFMEX.$body = $("body");
 TFMEX.prefs = {
-    "showChat": true,
+    "showChat": false,
     "showSong": true,
     "showVote": true,
     "showDJChanges": false,


### PR DESCRIPTION
After demo-ing this and speaking to a few people, the general feedback is that the chat notifications should be off by default - they can get pretty crazy in a busy room.

Mark, if you agree I'll merge this in tonight...

Adam
