### PR TITLE
Removing FB links on the user list page

### DIFF
--- a/chrome_extension/js/turntable.fm.extend.js
+++ b/chrome_extension/js/turntable.fm.extend.js
@@ -257,9 +257,6 @@ TFMEX.roomUserView = function(user) {
 		"div.tt.ext-room-user"
 	];
 	returnObj.push(["a",{href:"javascript:TFMEX.showUserProfile('" + user.userid + "')"},user.name]);
-	if(user.fbid !== "undefined") {
-		returnObj.push(["a",{href:'http://facebook.com/profile.php?id=' + user.fbid,target: "_blank",class:'tt-ext-aux-link'},"on Facebook"]);
-	}
     returnObj.push(["a",{href:'http://ttdashboard.com/user/f/' + user.fbid + '/',target: "_blank",class:'tt-ext-aux-link'},"on TTDashboard"])
 	/* Insert upvote messages next to user names
 	for (var i in TFMEX.roomInfo.upvoters) {


### PR DESCRIPTION
Removing FB links on the user list page - I think it goes against the spirit of TTFM, and I've seen feedback along the same lines... Submitted as a pull request so we can discuss it. What do you think?
